### PR TITLE
Change registry for `bitnami/kubectl` to docker.io

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -16,7 +16,7 @@ parameters:
         image: loftsh/vcluster
         tag: 0.5.0-beta.0
       kubectl:
-        repository: quay.io
+        repository: docker.io
         image: bitnami/kubectl
         tag: "1.22.4"
 

--- a/tests/golden/oidc/oidc/oidc/10_cluster.yaml
+++ b/tests/golden/oidc/oidc/oidc/10_cluster.yaml
@@ -325,7 +325,7 @@ spec:
               value: /export
             - name: VCLUSTER_SERVER_URL
               value: https://oidc:443
-          image: quay.io/bitnami/kubectl:1.22.4
+          image: docker.io/bitnami/kubectl:1.22.4
           imagePullPolicy: IfNotPresent
           name: oidc-apply-manifests
           ports: []
@@ -388,7 +388,7 @@ spec:
               value: /export
             - name: VCLUSTER_SERVER_URL
               value: https://oidc:443
-          image: quay.io/bitnami/kubectl:1.22.4
+          image: docker.io/bitnami/kubectl:1.22.4
           imagePullPolicy: IfNotPresent
           name: oidc-synthesize
           ports: []

--- a/tests/golden/openshift/openshift/openshift/10_cluster.yaml
+++ b/tests/golden/openshift/openshift/openshift/10_cluster.yaml
@@ -392,7 +392,7 @@ spec:
               value: syn-openshift
             - name: VCLUSTER_STS_NAME
               value: openshift
-          image: quay.io/bitnami/kubectl:1.22.4
+          image: docker.io/bitnami/kubectl:1.22.4
           imagePullPolicy: IfNotPresent
           name: openshift
           ports: []


### PR DESCRIPTION
The bitnami images have disappeared on quay.io. According to https://blog.bitnami.com/2021/07/vmware-joins-docker-verified-publisher.html docker.io/bitnami should be exempt from the pull rate limits.




## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
