### PR TITLE
Changes for vcluster dependency upgrades

### DIFF
--- a/component/coredns.libsonnet
+++ b/component/coredns.libsonnet
@@ -1,0 +1,238 @@
+local kap = import 'lib/kapitan.libjsonnet';
+local kube = import 'lib/kube.libjsonnet';
+local inv = kap.inventory();
+local common = import 'common.libsonnet';
+// The hiera parameters for the component
+local params = inv.parameters.vcluster;
+
+local corednsConfigMap =
+  function(name, namespace)
+    kube.ConfigMap('vc-%s-coredns' % name) {
+      metadata+: {
+        namespace: namespace,
+      },
+      data: {
+        // The deployment has some variables in there that get modified by vcluster.
+        // It is not valid yaml, so we need to use a string.
+        // The Helm chart does use a string too.
+        'coredns.yaml': |||
+          apiVersion: v1
+          kind: ServiceAccount
+          metadata:
+            name: coredns
+            namespace: kube-system
+          ---
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: ClusterRole
+          metadata:
+            labels:
+              kubernetes.io/bootstrapping: rbac-defaults
+            name: system:coredns
+          rules:
+            - apiGroups:
+                - ""
+              resources:
+                - endpoints
+                - services
+                - pods
+                - namespaces
+              verbs:
+                - list
+                - watch
+            - apiGroups:
+                - discovery.k8s.io
+              resources:
+                - endpointslices
+              verbs:
+                - list
+                - watch
+          ---
+          apiVersion: rbac.authorization.k8s.io/v1
+          kind: ClusterRoleBinding
+          metadata:
+            annotations:
+              rbac.authorization.kubernetes.io/autoupdate: "true"
+            labels:
+              kubernetes.io/bootstrapping: rbac-defaults
+            name: system:coredns
+          roleRef:
+            apiGroup: rbac.authorization.k8s.io
+            kind: ClusterRole
+            name: system:coredns
+          subjects:
+            - kind: ServiceAccount
+              name: coredns
+              namespace: kube-system
+          ---
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: coredns
+            namespace: kube-system
+          data:
+            Corefile: |
+              .:1053 {
+                  {{.LOG_IN_DEBUG}}
+                  errors
+                  health
+                  ready
+                  kubernetes cluster.local in-addr.arpa ip6.arpa {
+                    pods insecure
+                    fallthrough in-addr.arpa ip6.arpa
+                  }
+                  hosts /etc/coredns/NodeHosts {
+                    ttl 60
+                    reload 15s
+                    fallthrough
+                  }
+                  prometheus :9153
+                  forward . /etc/resolv.conf
+                  cache 30
+                  loop
+                  reload
+                  loadbalance
+              }
+
+              import /etc/coredns/custom/*.server
+            NodeHosts: ""
+          ---
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: coredns
+            namespace: kube-system
+            labels:
+              k8s-app: kube-dns
+              kubernetes.io/name: "CoreDNS"
+          spec:
+            replicas: 1
+            strategy:
+              type: RollingUpdate
+              rollingUpdate:
+                maxUnavailable: 1
+            selector:
+              matchLabels:
+                k8s-app: kube-dns
+            template:
+              metadata:
+                labels:
+                  k8s-app: kube-dns
+              spec:
+                priorityClassName: "system-cluster-critical"
+                serviceAccountName: coredns
+                nodeSelector:
+                  kubernetes.io/os: linux
+                topologySpreadConstraints:
+                  - maxSkew: 1
+                    topologyKey: kubernetes.io/hostname
+                    whenUnsatisfiable: DoNotSchedule
+                    labelSelector:
+                      matchLabels:
+                        k8s-app: kube-dns
+                containers:
+                  - name: coredns
+                    image: {{.IMAGE}}
+                    imagePullPolicy: IfNotPresent
+                    resources:
+                      limits:
+                        cpu: 1000m
+                        memory: 170Mi
+                      requests:
+                        cpu: 100m
+                        memory: 70Mi
+                    args: [ "-conf", "/etc/coredns/Corefile" ]
+                    volumeMounts:
+                      - name: config-volume
+                        mountPath: /etc/coredns
+                        readOnly: true
+                      - name: custom-config-volume
+                        mountPath: /etc/coredns/custom
+                        readOnly: true
+                    ports:
+                      - containerPort: 1053
+                        name: dns
+                        protocol: UDP
+                      - containerPort: 1053
+                        name: dns-tcp
+                        protocol: TCP
+                      - containerPort: 9153
+                        name: metrics
+                        protocol: TCP
+                    securityContext:
+                      runAsUser: {{.RUN_AS_USER}}
+                      runAsNonRoot: {{.RUN_AS_NON_ROOT}}
+                      allowPrivilegeEscalation: false
+                      capabilities:
+                        drop:
+                          - ALL
+                      readOnlyRootFilesystem: true
+                    livenessProbe:
+                      httpGet:
+                        path: /health
+                        port: 8080
+                        scheme: HTTP
+                      initialDelaySeconds: 60
+                      periodSeconds: 10
+                      timeoutSeconds: 1
+                      successThreshold: 1
+                      failureThreshold: 3
+                    readinessProbe:
+                      httpGet:
+                        path: /ready
+                        port: 8181
+                        scheme: HTTP
+                      initialDelaySeconds: 0
+                      periodSeconds: 2
+                      timeoutSeconds: 1
+                      successThreshold: 1
+                      failureThreshold: 3
+                dnsPolicy: Default
+                volumes:
+                  - name: config-volume
+                    configMap:
+                      name: coredns
+                      items:
+                        - key: Corefile
+                          path: Corefile
+                        - key: NodeHosts
+                          path: NodeHosts
+                  - name: custom-config-volume
+                    configMap:
+                      name: coredns-custom
+                      optional: true
+          ---
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: kube-dns
+            namespace: kube-system
+            annotations:
+              prometheus.io/port: "9153"
+              prometheus.io/scrape: "true"
+            labels:
+              k8s-app: kube-dns
+              kubernetes.io/cluster-service: "true"
+              kubernetes.io/name: "CoreDNS"
+          spec:
+            selector:
+              k8s-app: kube-dns
+            type: ClusterIP
+            ports:
+              - name: dns
+                port: 53
+                targetPort: 1053
+                protocol: UDP
+              - name: dns-tcp
+                port: 53
+                targetPort: 1053
+                protocol: TCP
+              - name: metrics
+                port: 9153
+                protocol: TCP
+        |||,
+      },
+    };
+
+{
+  corednsConfigMap: corednsConfigMap,
+}

--- a/component/post-setup.libsonnet
+++ b/component/post-setup.libsonnet
@@ -42,52 +42,6 @@ local synthesize = function(name, secretName, url)
     },
   };
 
-local applyManifests = function(name, secretName, manifests)
-  local jobName = '%s-apply-manifests' % name;
-  local manifestArray = if std.isArray(manifests) then
-    manifests
-  else if std.isObject(manifests) then
-    std.objectValues(manifests)
-  else
-    error 'Manifests must be array or object'
-  ;
-  kube.Job(jobName) {
-    metadata+: {
-      namespace: params.namespace,
-      annotations+: {
-        'argocd.argoproj.io/hook': 'PostSync',
-      },
-    },
-    spec+: {
-      template+: {
-        spec+: {
-          containers_+: {
-            patch_crds: kube.Container(jobName) {
-              image: common.formatImage(params.images.kubectl),
-              workingDir: '/export',
-              command: [ 'sh' ],
-              args: [ '-eu', '-c', importstr './scripts/apply.sh', '--' ] + std.map(function(m) std.manifestJsonEx(m, ''), manifestArray),
-              env: [
-                { name: 'HOME', value: '/export' },
-                { name: 'VCLUSTER_SERVER_URL', value: 'https://%s:443' % name },
-              ],
-              volumeMounts: [
-                { name: 'export', mountPath: '/export' },
-                { name: 'kubeconfig', mountPath: '/etc/vcluster-kubeconfig', readOnly: true },
-              ],
-            },
-          },
-          volumes+: [
-            { name: 'export', emptyDir: {} },
-            { name: 'kubeconfig', secret: { secretName: secretName } },
-          ],
-        },
-      },
-    },
-  };
-
-
 {
   Synthesize: synthesize,
-  ApplyManifests: applyManifests,
 }

--- a/tests/golden/defaults/defaults/defaults/10_cluster.yaml
+++ b/tests/golden/defaults/defaults/defaults/10_cluster.yaml
@@ -178,6 +178,8 @@ spec:
           volumeMounts:
             - mountPath: /data
               name: data
+            - mountPath: /etc/rancher
+              name: etc-rancher
         - args:
             - --name=defaults
             - --out-kube-config-secret=vc-defaults-kubeconfig
@@ -215,11 +217,20 @@ spec:
             - mountPath: /data
               name: data
               readOnly: true
+            - mountPath: /manifests/coredns
+              name: coredns
+              readOnly: true
       nodeSelector: {}
       serviceAccountName: vc-defaults
       terminationGracePeriodSeconds: 10
       tolerations: []
-      volumes: null
+      volumes:
+        - configMap:
+            defaultMode: 420
+            name: vc-defaults-coredns
+          name: coredns
+        - emptyDir: {}
+          name: etc-rancher
   volumeClaimTemplates:
     - metadata:
         name: data
@@ -230,3 +241,77 @@ spec:
           requests:
             storage: 5Gi
         storageClassName: null
+---
+apiVersion: v1
+data:
+  coredns.yaml: "apiVersion: v1\nkind: ServiceAccount\nmetadata:\n  name: coredns\n\
+    \  namespace: kube-system\n---\napiVersion: rbac.authorization.k8s.io/v1\nkind:\
+    \ ClusterRole\nmetadata:\n  labels:\n    kubernetes.io/bootstrapping: rbac-defaults\n\
+    \  name: system:coredns\nrules:\n  - apiGroups:\n      - \"\"\n    resources:\n\
+    \      - endpoints\n      - services\n      - pods\n      - namespaces\n    verbs:\n\
+    \      - list\n      - watch\n  - apiGroups:\n      - discovery.k8s.io\n    resources:\n\
+    \      - endpointslices\n    verbs:\n      - list\n      - watch\n---\napiVersion:\
+    \ rbac.authorization.k8s.io/v1\nkind: ClusterRoleBinding\nmetadata:\n  annotations:\n\
+    \    rbac.authorization.kubernetes.io/autoupdate: \"true\"\n  labels:\n    kubernetes.io/bootstrapping:\
+    \ rbac-defaults\n  name: system:coredns\nroleRef:\n  apiGroup: rbac.authorization.k8s.io\n\
+    \  kind: ClusterRole\n  name: system:coredns\nsubjects:\n  - kind: ServiceAccount\n\
+    \    name: coredns\n    namespace: kube-system\n---\napiVersion: v1\nkind: ConfigMap\n\
+    metadata:\n  name: coredns\n  namespace: kube-system\ndata:\n  Corefile: |\n \
+    \   .:1053 {\n        {{.LOG_IN_DEBUG}}\n        errors\n        health\n    \
+    \    ready\n        kubernetes cluster.local in-addr.arpa ip6.arpa {\n       \
+    \   pods insecure\n          fallthrough in-addr.arpa ip6.arpa\n        }\n  \
+    \      hosts /etc/coredns/NodeHosts {\n          ttl 60\n          reload 15s\n\
+    \          fallthrough\n        }\n        prometheus :9153\n        forward .\
+    \ /etc/resolv.conf\n        cache 30\n        loop\n        reload\n        loadbalance\n\
+    \    }\n\n    import /etc/coredns/custom/*.server\n  NodeHosts: \"\"\n---\napiVersion:\
+    \ apps/v1\nkind: Deployment\nmetadata:\n  name: coredns\n  namespace: kube-system\n\
+    \  labels:\n    k8s-app: kube-dns\n    kubernetes.io/name: \"CoreDNS\"\nspec:\n\
+    \  replicas: 1\n  strategy:\n    type: RollingUpdate\n    rollingUpdate:\n   \
+    \   maxUnavailable: 1\n  selector:\n    matchLabels:\n      k8s-app: kube-dns\n\
+    \  template:\n    metadata:\n      labels:\n        k8s-app: kube-dns\n    spec:\n\
+    \      priorityClassName: \"system-cluster-critical\"\n      serviceAccountName:\
+    \ coredns\n      nodeSelector:\n        kubernetes.io/os: linux\n      topologySpreadConstraints:\n\
+    \        - maxSkew: 1\n          topologyKey: kubernetes.io/hostname\n       \
+    \   whenUnsatisfiable: DoNotSchedule\n          labelSelector:\n            matchLabels:\n\
+    \              k8s-app: kube-dns\n      containers:\n        - name: coredns\n\
+    \          image: {{.IMAGE}}\n          imagePullPolicy: IfNotPresent\n      \
+    \    resources:\n            limits:\n              cpu: 1000m\n             \
+    \ memory: 170Mi\n            requests:\n              cpu: 100m\n            \
+    \  memory: 70Mi\n          args: [ \"-conf\", \"/etc/coredns/Corefile\" ]\n  \
+    \        volumeMounts:\n            - name: config-volume\n              mountPath:\
+    \ /etc/coredns\n              readOnly: true\n            - name: custom-config-volume\n\
+    \              mountPath: /etc/coredns/custom\n              readOnly: true\n\
+    \          ports:\n            - containerPort: 1053\n              name: dns\n\
+    \              protocol: UDP\n            - containerPort: 1053\n            \
+    \  name: dns-tcp\n              protocol: TCP\n            - containerPort: 9153\n\
+    \              name: metrics\n              protocol: TCP\n          securityContext:\n\
+    \            runAsUser: {{.RUN_AS_USER}}\n            runAsNonRoot: {{.RUN_AS_NON_ROOT}}\n\
+    \            allowPrivilegeEscalation: false\n            capabilities:\n    \
+    \          drop:\n                - ALL\n            readOnlyRootFilesystem: true\n\
+    \          livenessProbe:\n            httpGet:\n              path: /health\n\
+    \              port: 8080\n              scheme: HTTP\n            initialDelaySeconds:\
+    \ 60\n            periodSeconds: 10\n            timeoutSeconds: 1\n         \
+    \   successThreshold: 1\n            failureThreshold: 3\n          readinessProbe:\n\
+    \            httpGet:\n              path: /ready\n              port: 8181\n\
+    \              scheme: HTTP\n            initialDelaySeconds: 0\n            periodSeconds:\
+    \ 2\n            timeoutSeconds: 1\n            successThreshold: 1\n        \
+    \    failureThreshold: 3\n      dnsPolicy: Default\n      volumes:\n        -\
+    \ name: config-volume\n          configMap:\n            name: coredns\n     \
+    \       items:\n              - key: Corefile\n                path: Corefile\n\
+    \              - key: NodeHosts\n                path: NodeHosts\n        - name:\
+    \ custom-config-volume\n          configMap:\n            name: coredns-custom\n\
+    \            optional: true\n---\napiVersion: v1\nkind: Service\nmetadata:\n \
+    \ name: kube-dns\n  namespace: kube-system\n  annotations:\n    prometheus.io/port:\
+    \ \"9153\"\n    prometheus.io/scrape: \"true\"\n  labels:\n    k8s-app: kube-dns\n\
+    \    kubernetes.io/cluster-service: \"true\"\n    kubernetes.io/name: \"CoreDNS\"\
+    \nspec:\n  selector:\n    k8s-app: kube-dns\n  type: ClusterIP\n  ports:\n   \
+    \ - name: dns\n      port: 53\n      targetPort: 1053\n      protocol: UDP\n \
+    \   - name: dns-tcp\n      port: 53\n      targetPort: 1053\n      protocol: TCP\n\
+    \    - name: metrics\n      port: 9153\n      protocol: TCP\n"
+kind: ConfigMap
+metadata:
+  annotations: {}
+  labels:
+    name: vc-defaults-coredns
+  name: vc-defaults-coredns
+  namespace: syn-defaults

--- a/tests/golden/defaults/defaults/defaults/10_cluster.yaml
+++ b/tests/golden/defaults/defaults/defaults/10_cluster.yaml
@@ -244,6 +244,20 @@ spec:
 ---
 apiVersion: v1
 data:
+  manifests: '---
+
+
+    '
+kind: ConfigMap
+metadata:
+  annotations: {}
+  labels:
+    name: defaults-init-manifests
+  name: defaults-init-manifests
+  namespace: syn-defaults
+---
+apiVersion: v1
+data:
   coredns.yaml: "apiVersion: v1\nkind: ServiceAccount\nmetadata:\n  name: coredns\n\
     \  namespace: kube-system\n---\napiVersion: rbac.authorization.k8s.io/v1\nkind:\
     \ ClusterRole\nmetadata:\n  labels:\n    kubernetes.io/bootstrapping: rbac-defaults\n\

--- a/tests/golden/oidc/oidc/oidc/10_cluster.yaml
+++ b/tests/golden/oidc/oidc/oidc/10_cluster.yaml
@@ -182,6 +182,8 @@ spec:
           volumeMounts:
             - mountPath: /data
               name: data
+            - mountPath: /etc/rancher
+              name: etc-rancher
         - args:
             - --name=oidc
             - --out-kube-config-secret=vc-oidc-kubeconfig
@@ -219,14 +221,97 @@ spec:
             - mountPath: /data
               name: data
               readOnly: true
+            - mountPath: /manifests/coredns
+              name: coredns
+              readOnly: true
       nodeSelector: {}
       serviceAccountName: vc-oidc
       terminationGracePeriodSeconds: 10
       tolerations: []
       volumes:
+        - configMap:
+            defaultMode: 420
+            name: vc-oidc-coredns
+          name: coredns
+        - emptyDir: {}
+          name: etc-rancher
         - emptyDir: {}
           name: data
   volumeClaimTemplates: []
+---
+apiVersion: v1
+data:
+  coredns.yaml: "apiVersion: v1\nkind: ServiceAccount\nmetadata:\n  name: coredns\n\
+    \  namespace: kube-system\n---\napiVersion: rbac.authorization.k8s.io/v1\nkind:\
+    \ ClusterRole\nmetadata:\n  labels:\n    kubernetes.io/bootstrapping: rbac-defaults\n\
+    \  name: system:coredns\nrules:\n  - apiGroups:\n      - \"\"\n    resources:\n\
+    \      - endpoints\n      - services\n      - pods\n      - namespaces\n    verbs:\n\
+    \      - list\n      - watch\n  - apiGroups:\n      - discovery.k8s.io\n    resources:\n\
+    \      - endpointslices\n    verbs:\n      - list\n      - watch\n---\napiVersion:\
+    \ rbac.authorization.k8s.io/v1\nkind: ClusterRoleBinding\nmetadata:\n  annotations:\n\
+    \    rbac.authorization.kubernetes.io/autoupdate: \"true\"\n  labels:\n    kubernetes.io/bootstrapping:\
+    \ rbac-defaults\n  name: system:coredns\nroleRef:\n  apiGroup: rbac.authorization.k8s.io\n\
+    \  kind: ClusterRole\n  name: system:coredns\nsubjects:\n  - kind: ServiceAccount\n\
+    \    name: coredns\n    namespace: kube-system\n---\napiVersion: v1\nkind: ConfigMap\n\
+    metadata:\n  name: coredns\n  namespace: kube-system\ndata:\n  Corefile: |\n \
+    \   .:1053 {\n        {{.LOG_IN_DEBUG}}\n        errors\n        health\n    \
+    \    ready\n        kubernetes cluster.local in-addr.arpa ip6.arpa {\n       \
+    \   pods insecure\n          fallthrough in-addr.arpa ip6.arpa\n        }\n  \
+    \      hosts /etc/coredns/NodeHosts {\n          ttl 60\n          reload 15s\n\
+    \          fallthrough\n        }\n        prometheus :9153\n        forward .\
+    \ /etc/resolv.conf\n        cache 30\n        loop\n        reload\n        loadbalance\n\
+    \    }\n\n    import /etc/coredns/custom/*.server\n  NodeHosts: \"\"\n---\napiVersion:\
+    \ apps/v1\nkind: Deployment\nmetadata:\n  name: coredns\n  namespace: kube-system\n\
+    \  labels:\n    k8s-app: kube-dns\n    kubernetes.io/name: \"CoreDNS\"\nspec:\n\
+    \  replicas: 1\n  strategy:\n    type: RollingUpdate\n    rollingUpdate:\n   \
+    \   maxUnavailable: 1\n  selector:\n    matchLabels:\n      k8s-app: kube-dns\n\
+    \  template:\n    metadata:\n      labels:\n        k8s-app: kube-dns\n    spec:\n\
+    \      priorityClassName: \"system-cluster-critical\"\n      serviceAccountName:\
+    \ coredns\n      nodeSelector:\n        kubernetes.io/os: linux\n      topologySpreadConstraints:\n\
+    \        - maxSkew: 1\n          topologyKey: kubernetes.io/hostname\n       \
+    \   whenUnsatisfiable: DoNotSchedule\n          labelSelector:\n            matchLabels:\n\
+    \              k8s-app: kube-dns\n      containers:\n        - name: coredns\n\
+    \          image: {{.IMAGE}}\n          imagePullPolicy: IfNotPresent\n      \
+    \    resources:\n            limits:\n              cpu: 1000m\n             \
+    \ memory: 170Mi\n            requests:\n              cpu: 100m\n            \
+    \  memory: 70Mi\n          args: [ \"-conf\", \"/etc/coredns/Corefile\" ]\n  \
+    \        volumeMounts:\n            - name: config-volume\n              mountPath:\
+    \ /etc/coredns\n              readOnly: true\n            - name: custom-config-volume\n\
+    \              mountPath: /etc/coredns/custom\n              readOnly: true\n\
+    \          ports:\n            - containerPort: 1053\n              name: dns\n\
+    \              protocol: UDP\n            - containerPort: 1053\n            \
+    \  name: dns-tcp\n              protocol: TCP\n            - containerPort: 9153\n\
+    \              name: metrics\n              protocol: TCP\n          securityContext:\n\
+    \            runAsUser: {{.RUN_AS_USER}}\n            runAsNonRoot: {{.RUN_AS_NON_ROOT}}\n\
+    \            allowPrivilegeEscalation: false\n            capabilities:\n    \
+    \          drop:\n                - ALL\n            readOnlyRootFilesystem: true\n\
+    \          livenessProbe:\n            httpGet:\n              path: /health\n\
+    \              port: 8080\n              scheme: HTTP\n            initialDelaySeconds:\
+    \ 60\n            periodSeconds: 10\n            timeoutSeconds: 1\n         \
+    \   successThreshold: 1\n            failureThreshold: 3\n          readinessProbe:\n\
+    \            httpGet:\n              path: /ready\n              port: 8181\n\
+    \              scheme: HTTP\n            initialDelaySeconds: 0\n            periodSeconds:\
+    \ 2\n            timeoutSeconds: 1\n            successThreshold: 1\n        \
+    \    failureThreshold: 3\n      dnsPolicy: Default\n      volumes:\n        -\
+    \ name: config-volume\n          configMap:\n            name: coredns\n     \
+    \       items:\n              - key: Corefile\n                path: Corefile\n\
+    \              - key: NodeHosts\n                path: NodeHosts\n        - name:\
+    \ custom-config-volume\n          configMap:\n            name: coredns-custom\n\
+    \            optional: true\n---\napiVersion: v1\nkind: Service\nmetadata:\n \
+    \ name: kube-dns\n  namespace: kube-system\n  annotations:\n    prometheus.io/port:\
+    \ \"9153\"\n    prometheus.io/scrape: \"true\"\n  labels:\n    k8s-app: kube-dns\n\
+    \    kubernetes.io/cluster-service: \"true\"\n    kubernetes.io/name: \"CoreDNS\"\
+    \nspec:\n  selector:\n    k8s-app: kube-dns\n  type: ClusterIP\n  ports:\n   \
+    \ - name: dns\n      port: 53\n      targetPort: 1053\n      protocol: UDP\n \
+    \   - name: dns-tcp\n      port: 53\n      targetPort: 1053\n      protocol: TCP\n\
+    \    - name: metrics\n      port: 9153\n      protocol: TCP\n"
+kind: ConfigMap
+metadata:
+  annotations: {}
+  labels:
+    name: vc-oidc-coredns
+  name: vc-oidc-coredns
+  namespace: testns
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/tests/golden/oidc/oidc/oidc/10_cluster.yaml
+++ b/tests/golden/oidc/oidc/oidc/10_cluster.yaml
@@ -241,6 +241,21 @@ spec:
 ---
 apiVersion: v1
 data:
+  manifests: "---\n\"apiVersion\": \"rbac.authorization.k8s.io/v1\"\n\"kind\": \"\
+    ClusterRoleBinding\"\n\"metadata\":\n  \"name\": \"oidc-cluster-admin\"\n\"roleRef\"\
+    :\n  \"apiGroup\": \"rbac.authorization.k8s.io\"\n  \"kind\": \"ClusterRole\"\n\
+    \  \"name\": \"cluster-admin\"\n\"subjects\":\n- \"kind\": \"Group\"\n  \"name\"\
+    : \"admin\"\n"
+kind: ConfigMap
+metadata:
+  annotations: {}
+  labels:
+    name: oidc-init-manifests
+  name: oidc-init-manifests
+  namespace: testns
+---
+apiVersion: v1
+data:
   coredns.yaml: "apiVersion: v1\nkind: ServiceAccount\nmetadata:\n  name: coredns\n\
     \  namespace: kube-system\n---\napiVersion: rbac.authorization.k8s.io/v1\nkind:\
     \ ClusterRole\nmetadata:\n  labels:\n    kubernetes.io/bootstrapping: rbac-defaults\n\
@@ -338,101 +353,6 @@ spec:
     - hosts:
         - testcluster.local
       secretName: oidc-tls
----
-apiVersion: batch/v1
-kind: Job
-metadata:
-  annotations:
-    argocd.argoproj.io/hook: PostSync
-  labels:
-    name: oidc-apply-manifests
-  name: oidc-apply-manifests
-  namespace: testns
-spec:
-  completions: 1
-  parallelism: 1
-  template:
-    metadata:
-      labels:
-        name: oidc-apply-manifests
-    spec:
-      containers:
-        - args:
-            - -eu
-            - -c
-            - "#!/bin/sh\nset -eu\n\ncp /etc/vcluster-kubeconfig/config ./config\n\
-              vcluster_kubeconfig=./config\n\necho \"Setting server URL...\"\n\nkubectl\
-              \ --kubeconfig \"$vcluster_kubeconfig\" config set clusters.local.server\
-              \ \"$VCLUSTER_SERVER_URL\"\n\necho \"Applying manifests...\"\n\nfor\
-              \ manifest in \"$@\"\ndo\n  printf \"$manifest\" | kubectl --kubeconfig\
-              \ \"$vcluster_kubeconfig\" apply -f - -oyaml\ndone\n\necho \"Done!\"\
-              \n"
-            - --
-            - '{
-
-              "apiVersion": "rbac.authorization.k8s.io/v1",
-
-              "kind": "ClusterRoleBinding",
-
-              "metadata": {
-
-              "name": "oidc-cluster-admin"
-
-              },
-
-              "roleRef": {
-
-              "apiGroup": "rbac.authorization.k8s.io",
-
-              "kind": "ClusterRole",
-
-              "name": "cluster-admin"
-
-              },
-
-              "subjects": [
-
-              {
-
-              "kind": "Group",
-
-              "name": "admin"
-
-              }
-
-              ]
-
-              }'
-          command:
-            - sh
-          env:
-            - name: HOME
-              value: /export
-            - name: VCLUSTER_SERVER_URL
-              value: https://oidc:443
-          image: docker.io/bitnami/kubectl:1.24.3
-          imagePullPolicy: IfNotPresent
-          name: oidc-apply-manifests
-          ports: []
-          stdin: false
-          tty: false
-          volumeMounts:
-            - mountPath: /export
-              name: export
-            - mountPath: /etc/vcluster-kubeconfig
-              name: kubeconfig
-              readOnly: true
-          workingDir: /export
-      imagePullSecrets: []
-      initContainers: []
-      restartPolicy: OnFailure
-      terminationGracePeriodSeconds: 30
-      volumes:
-        - emptyDir: {}
-          name: export
-        - name: kubeconfig
-          secret:
-            secretName: vc-oidc-kubeconfig
 ---
 apiVersion: batch/v1
 kind: Job

--- a/tests/golden/openshift/openshift/openshift/10_cluster.yaml
+++ b/tests/golden/openshift/openshift/openshift/10_cluster.yaml
@@ -184,6 +184,8 @@ spec:
           volumeMounts:
             - mountPath: /data
               name: data
+            - mountPath: /etc/rancher
+              name: etc-rancher
         - args:
             - --name=openshift
             - --out-kube-config-secret=vc-openshift-kubeconfig
@@ -221,11 +223,20 @@ spec:
             - mountPath: /data
               name: data
               readOnly: true
+            - mountPath: /manifests/coredns
+              name: coredns
+              readOnly: true
       nodeSelector: {}
       serviceAccountName: vc-openshift
       terminationGracePeriodSeconds: 10
       tolerations: []
-      volumes: null
+      volumes:
+        - configMap:
+            defaultMode: 420
+            name: vc-openshift-coredns
+          name: coredns
+        - emptyDir: {}
+          name: etc-rancher
   volumeClaimTemplates:
     - metadata:
         name: data
@@ -236,6 +247,80 @@ spec:
           requests:
             storage: 5Gi
         storageClassName: null
+---
+apiVersion: v1
+data:
+  coredns.yaml: "apiVersion: v1\nkind: ServiceAccount\nmetadata:\n  name: coredns\n\
+    \  namespace: kube-system\n---\napiVersion: rbac.authorization.k8s.io/v1\nkind:\
+    \ ClusterRole\nmetadata:\n  labels:\n    kubernetes.io/bootstrapping: rbac-defaults\n\
+    \  name: system:coredns\nrules:\n  - apiGroups:\n      - \"\"\n    resources:\n\
+    \      - endpoints\n      - services\n      - pods\n      - namespaces\n    verbs:\n\
+    \      - list\n      - watch\n  - apiGroups:\n      - discovery.k8s.io\n    resources:\n\
+    \      - endpointslices\n    verbs:\n      - list\n      - watch\n---\napiVersion:\
+    \ rbac.authorization.k8s.io/v1\nkind: ClusterRoleBinding\nmetadata:\n  annotations:\n\
+    \    rbac.authorization.kubernetes.io/autoupdate: \"true\"\n  labels:\n    kubernetes.io/bootstrapping:\
+    \ rbac-defaults\n  name: system:coredns\nroleRef:\n  apiGroup: rbac.authorization.k8s.io\n\
+    \  kind: ClusterRole\n  name: system:coredns\nsubjects:\n  - kind: ServiceAccount\n\
+    \    name: coredns\n    namespace: kube-system\n---\napiVersion: v1\nkind: ConfigMap\n\
+    metadata:\n  name: coredns\n  namespace: kube-system\ndata:\n  Corefile: |\n \
+    \   .:1053 {\n        {{.LOG_IN_DEBUG}}\n        errors\n        health\n    \
+    \    ready\n        kubernetes cluster.local in-addr.arpa ip6.arpa {\n       \
+    \   pods insecure\n          fallthrough in-addr.arpa ip6.arpa\n        }\n  \
+    \      hosts /etc/coredns/NodeHosts {\n          ttl 60\n          reload 15s\n\
+    \          fallthrough\n        }\n        prometheus :9153\n        forward .\
+    \ /etc/resolv.conf\n        cache 30\n        loop\n        reload\n        loadbalance\n\
+    \    }\n\n    import /etc/coredns/custom/*.server\n  NodeHosts: \"\"\n---\napiVersion:\
+    \ apps/v1\nkind: Deployment\nmetadata:\n  name: coredns\n  namespace: kube-system\n\
+    \  labels:\n    k8s-app: kube-dns\n    kubernetes.io/name: \"CoreDNS\"\nspec:\n\
+    \  replicas: 1\n  strategy:\n    type: RollingUpdate\n    rollingUpdate:\n   \
+    \   maxUnavailable: 1\n  selector:\n    matchLabels:\n      k8s-app: kube-dns\n\
+    \  template:\n    metadata:\n      labels:\n        k8s-app: kube-dns\n    spec:\n\
+    \      priorityClassName: \"system-cluster-critical\"\n      serviceAccountName:\
+    \ coredns\n      nodeSelector:\n        kubernetes.io/os: linux\n      topologySpreadConstraints:\n\
+    \        - maxSkew: 1\n          topologyKey: kubernetes.io/hostname\n       \
+    \   whenUnsatisfiable: DoNotSchedule\n          labelSelector:\n            matchLabels:\n\
+    \              k8s-app: kube-dns\n      containers:\n        - name: coredns\n\
+    \          image: {{.IMAGE}}\n          imagePullPolicy: IfNotPresent\n      \
+    \    resources:\n            limits:\n              cpu: 1000m\n             \
+    \ memory: 170Mi\n            requests:\n              cpu: 100m\n            \
+    \  memory: 70Mi\n          args: [ \"-conf\", \"/etc/coredns/Corefile\" ]\n  \
+    \        volumeMounts:\n            - name: config-volume\n              mountPath:\
+    \ /etc/coredns\n              readOnly: true\n            - name: custom-config-volume\n\
+    \              mountPath: /etc/coredns/custom\n              readOnly: true\n\
+    \          ports:\n            - containerPort: 1053\n              name: dns\n\
+    \              protocol: UDP\n            - containerPort: 1053\n            \
+    \  name: dns-tcp\n              protocol: TCP\n            - containerPort: 9153\n\
+    \              name: metrics\n              protocol: TCP\n          securityContext:\n\
+    \            runAsUser: {{.RUN_AS_USER}}\n            runAsNonRoot: {{.RUN_AS_NON_ROOT}}\n\
+    \            allowPrivilegeEscalation: false\n            capabilities:\n    \
+    \          drop:\n                - ALL\n            readOnlyRootFilesystem: true\n\
+    \          livenessProbe:\n            httpGet:\n              path: /health\n\
+    \              port: 8080\n              scheme: HTTP\n            initialDelaySeconds:\
+    \ 60\n            periodSeconds: 10\n            timeoutSeconds: 1\n         \
+    \   successThreshold: 1\n            failureThreshold: 3\n          readinessProbe:\n\
+    \            httpGet:\n              path: /ready\n              port: 8181\n\
+    \              scheme: HTTP\n            initialDelaySeconds: 0\n            periodSeconds:\
+    \ 2\n            timeoutSeconds: 1\n            successThreshold: 1\n        \
+    \    failureThreshold: 3\n      dnsPolicy: Default\n      volumes:\n        -\
+    \ name: config-volume\n          configMap:\n            name: coredns\n     \
+    \       items:\n              - key: Corefile\n                path: Corefile\n\
+    \              - key: NodeHosts\n                path: NodeHosts\n        - name:\
+    \ custom-config-volume\n          configMap:\n            name: coredns-custom\n\
+    \            optional: true\n---\napiVersion: v1\nkind: Service\nmetadata:\n \
+    \ name: kube-dns\n  namespace: kube-system\n  annotations:\n    prometheus.io/port:\
+    \ \"9153\"\n    prometheus.io/scrape: \"true\"\n  labels:\n    k8s-app: kube-dns\n\
+    \    kubernetes.io/cluster-service: \"true\"\n    kubernetes.io/name: \"CoreDNS\"\
+    \nspec:\n  selector:\n    k8s-app: kube-dns\n  type: ClusterIP\n  ports:\n   \
+    \ - name: dns\n      port: 53\n      targetPort: 1053\n      protocol: UDP\n \
+    \   - name: dns-tcp\n      port: 53\n      targetPort: 1053\n      protocol: TCP\n\
+    \    - name: metrics\n      port: 9153\n      protocol: TCP\n"
+kind: ConfigMap
+metadata:
+  annotations: {}
+  labels:
+    name: vc-openshift-coredns
+  name: vc-openshift-coredns
+  namespace: syn-openshift
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/tests/golden/openshift/openshift/openshift/10_cluster.yaml
+++ b/tests/golden/openshift/openshift/openshift/10_cluster.yaml
@@ -250,6 +250,20 @@ spec:
 ---
 apiVersion: v1
 data:
+  manifests: '---
+
+
+    '
+kind: ConfigMap
+metadata:
+  annotations: {}
+  labels:
+    name: openshift-init-manifests
+  name: openshift-init-manifests
+  namespace: syn-openshift
+---
+apiVersion: v1
+data:
   coredns.yaml: "apiVersion: v1\nkind: ServiceAccount\nmetadata:\n  name: coredns\n\
     \  namespace: kube-system\n---\napiVersion: rbac.authorization.k8s.io/v1\nkind:\
     \ ClusterRole\nmetadata:\n  labels:\n    kubernetes.io/bootstrapping: rbac-defaults\n\


### PR DESCRIPTION
This PR:
- Uses an `emptyDir` volume for some temporary k3s files
- Uses the upstream way to apply manifests to the newly created cluster
- Updates the Coredns integration from the upstream Helm chart

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
