### PR TITLE
Update vcluster images

### DIFF
--- a/class/defaults.yml
+++ b/class/defaults.yml
@@ -10,15 +10,15 @@ parameters:
       k3s:
         registry: docker.io
         image: rancher/k3s
-        tag: v1.24.3-k3s1
+        tag: v1.25.2-k3s1
       syncer:
         registry: docker.io
         image: loftsh/vcluster
-        tag: "0.11.0"
+        tag: "0.12.2"
       kubectl:
         registry: docker.io
         image: bitnami/kubectl
-        tag: "1.24.4"
+        tag: "1.25.3"
 
     storage:
       persistence: true

--- a/component/cluster.libsonnet
+++ b/component/cluster.libsonnet
@@ -78,6 +78,19 @@ local cluster = function(name, options)
       },
       {
         apiGroups: [
+          'networking.k8s.io',
+        ],
+        resources: [
+          'ingressclasses',
+        ],
+        verbs: [
+          'get',
+          'list',
+          'watch',
+        ],
+      },
+      {
+        apiGroups: [
           'apps',
         ],
         resources: [

--- a/component/cluster.libsonnet
+++ b/component/cluster.libsonnet
@@ -312,6 +312,7 @@ local cluster = function(name, options)
               args: [
                 '--name=' + name,
                 '--out-kube-config-secret=vc-%s-kubeconfig' % name,
+                '--sync=ingresses',
               ] + tlsSANs + options.syncer.additional_args,
               livenessProbe: {
                 httpGet: {

--- a/tests/golden/defaults/defaults/defaults/10_cluster.yaml
+++ b/tests/golden/defaults/defaults/defaults/10_cluster.yaml
@@ -58,6 +58,14 @@ rules:
       - list
       - watch
   - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - apps
     resources:
       - statefulsets

--- a/tests/golden/defaults/defaults/defaults/10_cluster.yaml
+++ b/tests/golden/defaults/defaults/defaults/10_cluster.yaml
@@ -191,6 +191,7 @@ spec:
         - args:
             - --name=defaults
             - --out-kube-config-secret=vc-defaults-kubeconfig
+            - --sync=ingresses
             - --tls-san=defaults.syn-defaults.svc.cluster.local
             - --tls-san=defaults.syn-defaults.svc
             - --tls-san=defaults.syn-defaults

--- a/tests/golden/defaults/defaults/defaults/10_cluster.yaml
+++ b/tests/golden/defaults/defaults/defaults/10_cluster.yaml
@@ -165,7 +165,7 @@ spec:
           command:
             - /bin/k3s
           env: []
-          image: docker.io/rancher/k3s:v1.24.3-k3s1
+          image: docker.io/rancher/k3s:v1.25.2-k3s1
           name: vcluster
           resources:
             limits:
@@ -188,7 +188,7 @@ spec:
             - --tls-san=defaults.syn-defaults
             - --tls-san=defaults
           env: []
-          image: docker.io/loftsh/vcluster:0.11.0
+          image: docker.io/loftsh/vcluster:0.12.2
           livenessProbe:
             failureThreshold: 10
             httpGet:

--- a/tests/golden/oidc/oidc/oidc/10_cluster.yaml
+++ b/tests/golden/oidc/oidc/oidc/10_cluster.yaml
@@ -58,6 +58,14 @@ rules:
       - list
       - watch
   - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - apps
     resources:
       - statefulsets

--- a/tests/golden/oidc/oidc/oidc/10_cluster.yaml
+++ b/tests/golden/oidc/oidc/oidc/10_cluster.yaml
@@ -195,6 +195,7 @@ spec:
         - args:
             - --name=oidc
             - --out-kube-config-secret=vc-oidc-kubeconfig
+            - --sync=ingresses
             - --tls-san=oidc.testns.svc.cluster.local
             - --tls-san=oidc.testns.svc
             - --tls-san=oidc.testns

--- a/tests/golden/oidc/oidc/oidc/10_cluster.yaml
+++ b/tests/golden/oidc/oidc/oidc/10_cluster.yaml
@@ -169,7 +169,7 @@ spec:
           command:
             - /bin/k3s
           env: []
-          image: docker.io/rancher/k3s:v1.24.3-k3s1
+          image: docker.io/rancher/k3s:v1.25.2-k3s1
           name: vcluster
           resources:
             limits:
@@ -192,7 +192,7 @@ spec:
             - --tls-san=oidc.testns
             - --tls-san=oidc
           env: []
-          image: docker.io/loftsh/vcluster:0.11.0
+          image: docker.io/loftsh/vcluster:0.12.2
           livenessProbe:
             failureThreshold: 10
             httpGet:
@@ -393,7 +393,7 @@ spec:
               value: /export
             - name: VCLUSTER_SERVER_URL
               value: https://oidc:443
-          image: docker.io/bitnami/kubectl:1.24.4
+          image: docker.io/bitnami/kubectl:1.25.3
           imagePullPolicy: IfNotPresent
           name: oidc-synthesize
           ports: []

--- a/tests/golden/openshift/openshift/openshift/10_cluster.yaml
+++ b/tests/golden/openshift/openshift/openshift/10_cluster.yaml
@@ -171,7 +171,7 @@ spec:
           command:
             - /bin/k3s
           env: []
-          image: docker.io/rancher/k3s:v1.24.3-k3s1
+          image: docker.io/rancher/k3s:v1.25.2-k3s1
           name: vcluster
           resources:
             limits:
@@ -194,7 +194,7 @@ spec:
             - --tls-san=openshift.syn-openshift
             - --tls-san=openshift
           env: []
-          image: docker.io/loftsh/vcluster:0.11.0
+          image: docker.io/loftsh/vcluster:0.12.2
           livenessProbe:
             failureThreshold: 10
             httpGet:
@@ -491,7 +491,7 @@ spec:
               value: syn-openshift
             - name: VCLUSTER_STS_NAME
               value: openshift
-          image: docker.io/bitnami/kubectl:1.24.4
+          image: docker.io/bitnami/kubectl:1.25.3
           imagePullPolicy: IfNotPresent
           name: openshift
           ports: []

--- a/tests/golden/openshift/openshift/openshift/10_cluster.yaml
+++ b/tests/golden/openshift/openshift/openshift/10_cluster.yaml
@@ -58,6 +58,14 @@ rules:
       - list
       - watch
   - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
       - apps
     resources:
       - statefulsets

--- a/tests/golden/openshift/openshift/openshift/10_cluster.yaml
+++ b/tests/golden/openshift/openshift/openshift/10_cluster.yaml
@@ -197,6 +197,7 @@ spec:
         - args:
             - --name=openshift
             - --out-kube-config-secret=vc-openshift-kubeconfig
+            - --sync=ingresses
             - --tls-san=openshift.syn-openshift.svc.cluster.local
             - --tls-san=openshift.syn-openshift.svc
             - --tls-san=openshift.syn-openshift


### PR DESCRIPTION
vcluster shows a breaking change for `v0.12.0` where ingresses are no longer synced by default.

I reenabled ingress syncing by default.

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
