### PR TITLE
Move read permissions for `ingressclasses.networking.k8s.io` to ClusterRole

### DIFF
--- a/component/cluster.libsonnet
+++ b/component/cluster.libsonnet
@@ -78,19 +78,6 @@ local cluster = function(name, options)
       },
       {
         apiGroups: [
-          'networking.k8s.io',
-        ],
-        resources: [
-          'ingressclasses',
-        ],
-        verbs: [
-          'get',
-          'list',
-          'watch',
-        ],
-      },
-      {
-        apiGroups: [
           'apps',
         ],
         resources: [
@@ -125,6 +112,28 @@ local cluster = function(name, options)
     },
     subjects_: [ sa ],
     roleRef_: role,
+  };
+
+  local clusterRole = kube.ClusterRole('syn-vcluster-%s' % [ name ]) {
+    rules: [
+      {
+        apiGroups: [
+          'networking.k8s.io',
+        ],
+        resources: [
+          'ingressclasses',
+        ],
+        verbs: [
+          'get',
+          'list',
+          'watch',
+        ],
+      },
+    ],
+  };
+  local clusterRoleBinding = kube.ClusterRoleBinding('syn-vcluster-%s' % [ name ]) {
+    subjects_: [ sa ],
+    roleRef_: clusterRole,
   };
 
   local service = kube.Service(name) {
@@ -408,6 +417,8 @@ local cluster = function(name, options)
     sa,
     role,
     roleBinding,
+    clusterRole,
+    clusterRoleBinding,
     service,
     headlessService,
     statefulSet,

--- a/tests/golden/defaults/defaults/defaults/10_cluster.yaml
+++ b/tests/golden/defaults/defaults/defaults/10_cluster.yaml
@@ -58,14 +58,6 @@ rules:
       - list
       - watch
   - apiGroups:
-      - networking.k8s.io
-    resources:
-      - ingressclasses
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
       - apps
     resources:
       - statefulsets
@@ -88,6 +80,39 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: defaults
+subjects:
+  - kind: ServiceAccount
+    name: vc-defaults
+    namespace: syn-defaults
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: syn-vcluster-defaults
+  name: syn-vcluster-defaults
+rules:
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: {}
+  labels:
+    name: syn-vcluster-defaults
+  name: syn-vcluster-defaults
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: syn-vcluster-defaults
 subjects:
   - kind: ServiceAccount
     name: vc-defaults

--- a/tests/golden/oidc/oidc/oidc/10_cluster.yaml
+++ b/tests/golden/oidc/oidc/oidc/10_cluster.yaml
@@ -58,14 +58,6 @@ rules:
       - list
       - watch
   - apiGroups:
-      - networking.k8s.io
-    resources:
-      - ingressclasses
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
       - apps
     resources:
       - statefulsets
@@ -88,6 +80,39 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: oidc
+subjects:
+  - kind: ServiceAccount
+    name: vc-oidc
+    namespace: testns
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: syn-vcluster-oidc
+  name: syn-vcluster-oidc
+rules:
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: {}
+  labels:
+    name: syn-vcluster-oidc
+  name: syn-vcluster-oidc
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: syn-vcluster-oidc
 subjects:
   - kind: ServiceAccount
     name: vc-oidc

--- a/tests/golden/openshift/openshift/openshift/10_cluster.yaml
+++ b/tests/golden/openshift/openshift/openshift/10_cluster.yaml
@@ -58,14 +58,6 @@ rules:
       - list
       - watch
   - apiGroups:
-      - networking.k8s.io
-    resources:
-      - ingressclasses
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
       - apps
     resources:
       - statefulsets
@@ -94,6 +86,39 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: openshift
+subjects:
+  - kind: ServiceAccount
+    name: vc-openshift
+    namespace: syn-openshift
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  annotations: {}
+  labels:
+    name: syn-vcluster-openshift
+  name: syn-vcluster-openshift
+rules:
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - ingressclasses
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  annotations: {}
+  labels:
+    name: syn-vcluster-openshift
+  name: syn-vcluster-openshift
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: syn-vcluster-openshift
 subjects:
   - kind: ServiceAccount
     name: vc-openshift


### PR DESCRIPTION
`IngressClass` is a cluster-scoped resource, so granting read permissions to the ServiceAccount in a namespaced role and rolebinding isn't sufficient.

This commit changes the logic to generate a ClusterRole and ClusterRoleBinding which allow the SA to `get/list/watch` `IngressClass` resources.

Follow-up for #40  

Fixes #41 

## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
