### PR TITLE
Fix certificate errors in vcluster container

### DIFF
--- a/component/cluster.libsonnet
+++ b/component/cluster.libsonnet
@@ -345,7 +345,17 @@ local cluster = function(name, options)
               securityContext: {
                 allowPrivilegeEscalation: false,
               },
-              env: [],
+              env: [
+                // ensure that syncer TLS certificate is also valid for pod IP
+                {
+                  name: 'POD_IP',
+                  valueFrom: {
+                    fieldRef: {
+                      fieldPath: 'status.podIP',
+                    },
+                  },
+                },
+              ],
               volumeMounts: [
                 {
                   mountPath: '/data',

--- a/tests/golden/defaults/defaults/defaults/10_cluster.yaml
+++ b/tests/golden/defaults/defaults/defaults/10_cluster.yaml
@@ -221,7 +221,11 @@ spec:
             - --tls-san=defaults.syn-defaults.svc
             - --tls-san=defaults.syn-defaults
             - --tls-san=defaults
-          env: []
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
           image: docker.io/loftsh/vcluster:0.12.2
           livenessProbe:
             failureThreshold: 10

--- a/tests/golden/oidc/oidc/oidc/10_cluster.yaml
+++ b/tests/golden/oidc/oidc/oidc/10_cluster.yaml
@@ -225,7 +225,11 @@ spec:
             - --tls-san=oidc.testns.svc
             - --tls-san=oidc.testns
             - --tls-san=oidc
-          env: []
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
           image: docker.io/loftsh/vcluster:0.12.2
           livenessProbe:
             failureThreshold: 10

--- a/tests/golden/openshift/openshift/openshift/10_cluster.yaml
+++ b/tests/golden/openshift/openshift/openshift/10_cluster.yaml
@@ -227,7 +227,11 @@ spec:
             - --tls-san=openshift.syn-openshift.svc
             - --tls-san=openshift.syn-openshift
             - --tls-san=openshift
-          env: []
+          env:
+            - name: POD_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
           image: docker.io/loftsh/vcluster:0.12.2
           livenessProbe:
             failureThreshold: 10


### PR DESCRIPTION
We need to ensure that the syncer's TLS certificate is also valid for the pod IP. This only needs the pod IP passed to the container as an environment variable, cf. https://github.com/loft-sh/vcluster/pull/549

Follow-up for #40


## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [x] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
