### PR TITLE
Allow vcluster containers to run with arbitrary non-root UIDs on OpenShift

### DIFF
--- a/tests/golden/openshift/openshift/openshift/10_cluster.yaml
+++ b/tests/golden/openshift/openshift/openshift/10_cluster.yaml
@@ -124,6 +124,43 @@ subjects:
     name: vc-openshift
     namespace: syn-openshift
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  annotations: {}
+  labels:
+    name: use-nonroot-v2
+  name: use-nonroot-v2
+  namespace: syn-openshift
+rules:
+  - apiGroups:
+      - security.openshift.io
+    resourceNames:
+      - nonroot-v2
+    resources:
+      - securitycontextconstraints
+    verbs:
+      - use
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  annotations:
+    vcluster.syn.tools/description: Allow vcluster to sync pods with arbitrary nonroot
+      users by allowing the default ServiceAccount to use the nonroot-v2 scc
+  labels:
+    name: default-use-nonroot-v2
+  name: default-use-nonroot-v2
+  namespace: syn-openshift
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: use-nonroot-v2
+subjects:
+  - kind: ServiceAccount
+    name: default
+    namespace: syn-openshift
+---
 apiVersion: v1
 kind: Service
 metadata:


### PR DESCRIPTION
This is required for the argocd-operator managed Redis. While the operator will auto-detect OCP4 when running on an OpenShift cluster, this logic doesn't work (and wouldn't help in any case) when running in a vcluster on OCP4.

Instead of doing some complicated configuration, we just allow the default serviceaccount in the vcluster namespace to use the `nonroot-v2` SCC so that vcluster can sync pods with arbitrary non-root UIDs to the host cluster on OCP4.

## Checklist

- [x] The PR has a meaningful title. It will be used to auto generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
