### PR TITLE
Update CoreDNS template to match upstream template

### DIFF
--- a/component/coredns.libsonnet
+++ b/component/coredns.libsonnet
@@ -159,8 +159,9 @@ local corednsConfigMap =
                         name: metrics
                         protocol: TCP
                     securityContext:
+                      runAsNonRoot: true
                       runAsUser: {{.RUN_AS_USER}}
-                      runAsNonRoot: {{.RUN_AS_NON_ROOT}}
+                      runAsGroup: {{.RUN_AS_GROUP}}
                       allowPrivilegeEscalation: false
                       capabilities:
                         drop:

--- a/tests/golden/defaults/defaults/defaults/10_cluster.yaml
+++ b/tests/golden/defaults/defaults/defaults/10_cluster.yaml
@@ -439,8 +439,9 @@ data:
                   name: metrics
                   protocol: TCP
               securityContext:
+                runAsNonRoot: true
                 runAsUser: {{.RUN_AS_USER}}
-                runAsNonRoot: {{.RUN_AS_NON_ROOT}}
+                runAsGroup: {{.RUN_AS_GROUP}}
                 allowPrivilegeEscalation: false
                 capabilities:
                   drop:

--- a/tests/golden/oidc/oidc/oidc/10_cluster.yaml
+++ b/tests/golden/oidc/oidc/oidc/10_cluster.yaml
@@ -446,8 +446,9 @@ data:
                   name: metrics
                   protocol: TCP
               securityContext:
+                runAsNonRoot: true
                 runAsUser: {{.RUN_AS_USER}}
-                runAsNonRoot: {{.RUN_AS_NON_ROOT}}
+                runAsGroup: {{.RUN_AS_GROUP}}
                 allowPrivilegeEscalation: false
                 capabilities:
                   drop:

--- a/tests/golden/openshift/openshift/openshift/10_cluster.yaml
+++ b/tests/golden/openshift/openshift/openshift/10_cluster.yaml
@@ -482,8 +482,9 @@ data:
                   name: metrics
                   protocol: TCP
               securityContext:
+                runAsNonRoot: true
                 runAsUser: {{.RUN_AS_USER}}
-                runAsNonRoot: {{.RUN_AS_NON_ROOT}}
+                runAsGroup: {{.RUN_AS_GROUP}}
                 allowPrivilegeEscalation: false
                 capabilities:
                   drop:


### PR DESCRIPTION
This commit updates the CoreDNS template managed by the component to match the template present in the vcluster v0.14.1 Helm chart.

This should fix the sync issues we've observed recently.

Fixes #75




## Checklist

- [x] The PR has a meaningful title. It will be used to auto-generate the
      changelog.
      The PR has a meaningful description that sums up the change. It will be
      linked in the changelog.
- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.


<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards
while the PR is open.
-->
